### PR TITLE
Fix always having the same config

### DIFF
--- a/conan/recipes/harmony/cmake/MHCHelper.cmake
+++ b/conan/recipes/harmony/cmake/MHCHelper.cmake
@@ -80,7 +80,7 @@ function(add_harmony_config)
         set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS "${YAML_FILE}")
     endforeach ()
     list(JOIN _yml_hashes "" _yml_hash_concat)
-    string(SHA256 HARMONY_MHC_CONFIG_ID _yml_hash_concat)
+    string(SHA256 HARMONY_MHC_CONFIG_ID ${_yml_hash_concat})
 
     # STEP 2: Create working directory and copy files into expected structure
     set(HARMONY_MHC_GEN_WORKDIR "${CMAKE_CURRENT_BINARY_DIR}/Generated/MHC-${HARMONY_MHC_CONFIG_ID}/")


### PR DESCRIPTION
The accidentally-missing curly braces cause CMake to always take the hash of the '_yml_hash_concat' *string*, instead of the actual contents of the variable named this way.

Closes #13